### PR TITLE
-aオプションの実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,10 +9,11 @@ opt.parse!(ARGV)
 
 def contents
   if @option[:a] == true
-      files = Dir.glob("*", File::FNM_DOTMATCH)
+    option_a = File::FNM_DOTMATCH
   else
-    files = Dir.glob("*")
+    option_a = 0
   end
+  files = Dir.glob("*", option_a)
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 require 'optparse'
 
-opt = OptionParser.new
-$option = {}
-opt.on('-a') { |v| $option[:a] = v }
-opt.parse!(ARGV)
-
 def contents
-  option_a = ($option[:a] == true ? File::FNM_DOTMATCH : 0)
+  opt = OptionParser.new
+  option = {}
+  opt.on('-a') { |v| option[:a] = v }
+  opt.parse!(ARGV)
+
+  option_a = (option[:a] == true ? File::FNM_DOTMATCH : 0)
   files = Dir.glob("*", option_a)
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,12 +3,12 @@
 require 'optparse'
 
 opt = OptionParser.new
-@option = {}
-opt.on('-a') { |v| @option[:a] = v }
+$option = {}
+opt.on('-a') { |v| $option[:a] = v }
 opt.parse!(ARGV)
 
 def contents
-  if @option[:a] == true
+  if $option[:a] == true
     option_a = File::FNM_DOTMATCH
   else
     option_a = 0

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,8 +1,18 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+require 'optparse'
+
+opt = OptionParser.new
+opt.on('-a') { |v| p v }
 
 def contents
-  files = Dir.glob("*")
+  if ARGV.any?(/-\w/) == true
+    if ARGV.any?(/a/) == true
+      files = Dir.glob("*", File::FNM_DOTMATCH)
+    end
+  else
+    files = Dir.glob("*")
+  end
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,13 +6,15 @@ opt = OptionParser.new
 opt.on('-a') { |v| p v }
 
 def contents
+  files = Dir.glob("*")
   if ARGV.any?(/-\w/) == true
     if ARGV.any?(/a/) == true
       files = Dir.glob("*", File::FNM_DOTMATCH)
     end
-  else
-    files = Dir.glob("*")
+  elsif ARGV.include?('-') == true
+    raise OptionParser::InvalidOption
   end
+
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,11 +8,7 @@ opt.on('-a') { |v| $option[:a] = v }
 opt.parse!(ARGV)
 
 def contents
-  if $option[:a] == true
-    option_a = File::FNM_DOTMATCH
-  else
-    option_a = 0
-  end
+  option_a = ($option[:a] == true ? File::FNM_DOTMATCH : 0)
   files = Dir.glob("*", option_a)
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,18 +3,16 @@
 require 'optparse'
 
 opt = OptionParser.new
-opt.on('-a') { |v| p v }
+@option = {}
+opt.on('-a') { |v| @option[:a] = v }
+opt.parse!(ARGV)
 
 def contents
-  files = Dir.glob("*")
-  if ARGV.any?(/-\w/) == true
-    if ARGV.any?(/a/) == true
+  if @option[:a] == true
       files = Dir.glob("*", File::FNM_DOTMATCH)
-    end
-  elsif ARGV.include?('-') == true
-    raise OptionParser::InvalidOption
+  else
+    files = Dir.glob("*")
   end
-
   rows = files.length.ceildiv(3)
   file_rows = Array.new(rows) { Array.new(3) }
 


### PR DESCRIPTION
変更点
- -aオプションの実装
  - optparseを使用し、オプションを取得
  - 使用したオプションによって、取得するファイル配列の方法を分岐